### PR TITLE
Added default dummy jasypt startup property

### DIFF
--- a/src/main/resources/application-isobar-development.properties
+++ b/src/main/resources/application-isobar-development.properties
@@ -1,7 +1,9 @@
 # Set encrypted properties by starting this application then using:
 # http://localhost:8080/encrypt?message=whateveryouwant
-# to get the encrypted value
-# Don't forget to set the the JVM arg with the key: -Djasypt.encryptor.password=<whatever the key is> 
+# to get the encrypted value. The login for this URL is the default
+# Spring Security credentials (username 'user', password is randomly
+# generated and output on server startup as INFO).
+# Don't forget to set the the JVM arg with the key: -Djasypt.encryptor.password=<whatever the key is>
 exchange.uri=ENC(ITw87JAEasasoLUIGUSGmg5P1BZ55J2n/4rTd2OfYQyRzt7BxoaDbyz+0tiy/nKGw6MYL/0UpmU=)
 exchange.credentials.username=ENC(ks2JuUPubLqLNvRzoA0Z0odhaFetE6XO)
 exchange.credentials.password=ENC(qvr3ZJAYyRVKbSzwiqHE8AUuLI/qdzo6)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.thymeleaf.prefix=classpath:/static/
 # Webpack (specifically, indexhtml-webpack-plugin) doesn't output valid XML (which isn't bad, HTML5 doesn't have to be valid XML).
 # The Thymeleaf default mode, "HTML5", requires valid XML, so use "LEGACYHTML5" which works with non-XML.
 spring.thymeleaf.mode=LEGACYHTML5
+jasypt.encryptor.password=dummyValueWhenUsingEnvVariables


### PR DESCRIPTION
Not specifying one on startup would cause it to fail even if not using encrypted values
